### PR TITLE
fix: use PAT for release creation

### DIFF
--- a/.github/workflows/auto_release.yml
+++ b/.github/workflows/auto_release.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/create-release@v1 
         if: ${{ steps.changelog.outputs.skipped == 'false' }} 
         env: 
-          GITHUB_TOKEN: ${{ secrets.github_token }} 
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }} 
         with: 
           tag_name: ${{ steps.changelog.outputs.tag }}
           release_name: ${{ steps.changelog.outputs.tag }} 


### PR DESCRIPTION
use PAT instead of default actions token, to ensure release is triggered for deployment.